### PR TITLE
Enable PHP 8.3 compat

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.0", "8.1"]'
-      current_stable: 8.2
+      old_stable: '["8.0", "8.1", "8.2"]'
+      current_stable: 8.3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <2023> <Akihito Koriyama>
+Copyright (c) <2023-2024> <Akihito Koriyama>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6.19",
         "ext-curl": "*",
         "psalm/plugin-phpunit": "^0.18.4"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflow to use the latest stable version `8.3`.
  - Updated copyright year in the LICENSE file.
  - Updated PHPUnit dependency in `composer.json` to version `^9.6.19`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->