### PR TITLE
docs(license): update copyright year(s)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023-2024 <Akihito Koriyama>
+Copyright (c) 2023-2025 <Akihito Koriyama>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the copyright year in the MIT License from 2024 to 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->