### PR TITLE
Enable PHP 8.5 compat

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.0", "8.1", "8.2", "8.3"]'
-      current_stable: 8.4
+      old_stable: '["8.0", "8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- 旧安定版のバージョンに PHP 8.4 を含めるよう CI ワークフローのマトリクスを調整し、PHP 8.5 を現在の安定版として設定しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust CI workflow matrix to include PHP 8.4 in old stable versions and set PHP 8.5 as the current stable.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to reflect changes in supported development environment versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->